### PR TITLE
Fix: Resolve IndentationError in BioSample XML processing

### DIFF
--- a/api/handler.py
+++ b/api/handler.py
@@ -414,9 +414,35 @@ def _fetch_single_microbe_details(tax_id):
                 try:
                     root_node_str = f"<BioSampleSet>{biosample_xml_data}</BioSampleSet>" 
                     parsed_biosamples_root = ET.fromstring(root_node_str)
-                    for sample_node in parsed_biosamples_root.findall('BioSample'): # Moved loop inside try
+                    # Loop must be inside the try block that creates parsed_biosamples_root
+                    for sample_node in parsed_biosamples_root.findall('BioSample'):
                         sample_xml_str = ET.tostring(sample_node, encoding='unicode')
                         parsed_sample_data = parse_biosample_xml(sample_xml_str) # This helper already looks for Gram stain
+                        
+                        # Stretch goal: Oxygen requirement from BioSample attributes
+                        if not oxygen_requirement_general and parsed_sample_data.get("attributes"):
+                            for attr in parsed_sample_data["attributes"]:
+                                attr_name_lower = attr.get("name", "").lower()
+                                attr_val_lower = attr.get("value", "").lower()
+                                if "oxygen" in attr_name_lower or "aerobic" in attr_name_lower or "anaerobic" in attr_name_lower:
+                                    if "aerobic" in attr_val_lower: oxygen_requirement_general = "Aerobic"
+                                    elif "anaerobic" in attr_val_lower: oxygen_requirement_general = "Anaerobic"
+                                    elif "facultative" in attr_val_lower: oxygen_requirement_general = "Facultative"
+                                    elif "microaerophilic" in attr_val_lower: oxygen_requirement_general = "Microaerophilic"
+                                    break 
+                        
+                        if parsed_sample_data:
+                            result["biosample_info"].append(parsed_sample_data)
+                            if not gram_stain_general and "gram_stain_biosample" in parsed_sample_data:
+                                gram_stain_general = parsed_sample_data["gram_stain_biosample"]
+                except ET.ParseError as pe_multi:
+                    print(f"[BIOSAMPLE_MULTI_PARSE_ERR] XML Parse Error for BioSampleSet TaxID {tax_id}: {pe_multi}")
+                except Exception as e_bs_parse: # Catch any other error during biosample parsing
+                    print(f"[BIOSAMPLE_GENERIC_PARSE_ERR] Error parsing BioSample XML for TaxID {tax_id}: {e_bs_parse}")
+            
+    
+    # Consolidate Gram stain and Oxygen requirement
+    result["gram_stain_derived"] = gram_stain_general if gram_stain_general else "Not found"
                         
                         # Stretch goal: Oxygen requirement from BioSample attributes
                         if not oxygen_requirement_general and parsed_sample_data.get("attributes"):


### PR DESCRIPTION
Corrects an IndentationError (previously misdiagnosed as a SyntaxError at one point) in `api/handler.py` within the `_fetch_single_microbe_details` function, specifically in the lambda responsible for BioSample data processing.

The error was caused by the loop iterating through `BioSample` nodes and subsequent conditional checks (like for oxygen requirement) being incorrectly indented outside or improperly structured relative to the `try` block that parsed the BioSample XML.

This commit ensures that all BioSample XML parsing and data extraction logic, including the node iteration and attribute processing, is correctly scoped within the main `try` block. Appropriate `except ET.ParseError` and `except Exception` clauses are in place for this block.

This fix is critical for restoring the functionality of the API, which was failing due to this indentation error.